### PR TITLE
Use new 11.4 dev-pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v3

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v2
-    with:
-      ivyVersion: nightly-10

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,3 +9,7 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v3
+    with:
+      # temporary: disable script validation ... connector uses a variable not compatible with 11.4!
+      mvnArgs: '-Divy.script.validation.skip=true'
+

--- a/a-trust-connector-demo/pom.xml
+++ b/a-trust-connector-demo/pom.xml
@@ -6,6 +6,9 @@
   <artifactId>a-trust-connector-demo</artifactId>
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.atrust</groupId>
@@ -19,7 +22,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/a-trust-connector-demo/pom.xml
+++ b/a-trust-connector-demo/pom.xml
@@ -7,7 +7,7 @@
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/a-trust-connector-demo/pom.xml
+++ b/a-trust-connector-demo/pom.xml
@@ -9,6 +9,16 @@
   <properties>
     <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.atrust</groupId>

--- a/a-trust-connector-test/pom.xml
+++ b/a-trust-connector-test/pom.xml
@@ -7,7 +7,7 @@
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
     <tester.version>10.0.0</tester.version>
   </properties>
   <dependencies>

--- a/a-trust-connector-test/pom.xml
+++ b/a-trust-connector-test/pom.xml
@@ -6,17 +6,21 @@
   <artifactId>a-trust-connector-test</artifactId>
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+    <tester.version>10.0.0</tester.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.ivy.test</groupId>
       <artifactId>unit-tester</artifactId>
-      <version>10.0.0</version>
+      <version>${tester.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.axonivy.ivy.webtest</groupId>
       <artifactId>web-tester</artifactId>
-      <version>10.0.0</version>
+      <version>${tester.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -49,7 +53,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/a-trust-connector-test/pom.xml
+++ b/a-trust-connector-test/pom.xml
@@ -10,6 +10,25 @@
     <project.build.plugin.version>10.0.16</project.build.plugin.version>
     <tester.version>10.0.16</tester.version>
   </properties>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.ivy.test</groupId>

--- a/a-trust-connector-test/pom.xml
+++ b/a-trust-connector-test/pom.xml
@@ -8,7 +8,7 @@
   <packaging>iar</packaging>
   <properties>
     <project.build.plugin.version>10.0.16</project.build.plugin.version>
-    <tester.version>10.0.0</tester.version>
+    <tester.version>10.0.16</tester.version>
   </properties>
   <dependencies>
     <dependency>

--- a/a-trust-connector/pom.xml
+++ b/a-trust-connector/pom.xml
@@ -9,6 +9,16 @@
   <properties>
     <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <build>
     <plugins>
       <plugin>

--- a/a-trust-connector/pom.xml
+++ b/a-trust-connector/pom.xml
@@ -6,12 +6,15 @@
   <artifactId>a-trust-connector</artifactId>
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+  </properties>
   <build>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/a-trust-connector/pom.xml
+++ b/a-trust-connector/pom.xml
@@ -7,7 +7,7 @@
   <version>10.0.1-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.6</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Update pipelines to v3 which are aware of the capabilities of 11.4: This change should serve as sample how to update other market-artifacts to comply with the ivy-core:11.4

- introduces a property to steer the `project.build.plugin.version` and `tester.version`
- adds snapshot repositories to the POM's in order to consume SNAPSHOT artifacts during dev-pipeline runs
- upgrade the versions to the latest available from 10.X using the maven cli command line:
- `mvn --batch-mode versions:set-property versions:commit -Dproperty=project.build.plugin.version -DnewVersion=10.0.16 -DallowSnapshots=true`
- `mvn --batch-mode versions:set-property versions:commit -Dproperty=tester.version -DnewVersion=10.0.16 -DallowSnapshots=true`

for traceability I'd love to see this taken as receipt, also in terms of its history. each change is an own commit. manual and automated changes come separate.

- if you need to build a hack to comply with 11.4, please isolate it in a distinct commit, and create an issue for it, just like I did it by example on #32 . You can than plan to actually introduce distinct versions targeting leading-edge releases, to get rid of such technical depts. Ask @ivy-sgi to plan these efforts.

This reverts commit 53242e2e6bc4238931377cf852fdf34e7490cea0.